### PR TITLE
More docs

### DIFF
--- a/bagofholding/bag.py
+++ b/bagofholding/bag.py
@@ -1,3 +1,14 @@
+"""
+The core user-facing object.
+
+Full implementations of bags should guarantee the key features promised by the package:
+- Storage and retrieval of arbitrary pickleable python objects
+- Metadata preservation
+- Versioning verification
+- Browsing without loading
+- Partial reloading
+"""
+
 from __future__ import annotations
 
 import abc

--- a/bagofholding/content.py
+++ b/bagofholding/content.py
@@ -1,3 +1,12 @@
+"""
+Content controls the decomposition of python objects into their component parts, along
+with a record of what type of object they are, and gathering any relevant metadata.
+
+Content is not, of itself, concerned with what you _do_ with this decompositon.
+That is handled via the "packer" protocol (for us, the relevant implementation of this
+is "bags").
+"""
+
 from __future__ import annotations
 
 import abc

--- a/bagofholding/exceptions.py
+++ b/bagofholding/exceptions.py
@@ -1,3 +1,9 @@
+"""
+A centralized location for exceptions.
+
+Using custom exceptions allows us to be much more specific in the test suite.
+"""
+
 from __future__ import annotations
 
 

--- a/bagofholding/h5/bag.py
+++ b/bagofholding/h5/bag.py
@@ -22,6 +22,13 @@ class H5Info(BagInfo):
 
 
 class H5Bag(Bag, HasH5FileContext, ArrayPacker):
+    """
+    A bag using HDF5 files based on `h5py`.
+
+    The underlying file structure is directly representative of the structure of the
+    decomposed object being stored, and `attrs` are used to store metadata.
+    """
+
     _content_key: ClassVar[str] = "content_type"
 
     @classmethod

--- a/bagofholding/h5/content.py
+++ b/bagofholding/h5/content.py
@@ -1,3 +1,5 @@
+# Designed and intended for use with H5 implementations, which treat arrays very nicely
+# but since bags merely follow a protocol, there is nothing intrinsically-h5 here
 from __future__ import annotations
 
 from typing import Protocol, TypeAlias

--- a/bagofholding/h5/context.py
+++ b/bagofholding/h5/context.py
@@ -8,6 +8,10 @@ from bagofholding.exceptions import FileAlreadyOpenError, FileNotOpenError
 
 
 class HasH5FileContext:
+    """
+    A mixin class for context management with an :class:`h5py.File` object.
+    """
+
     libver_str: ClassVar[str] = "latest"
 
     filepath: pathlib.Path

--- a/bagofholding/h5/triebag.py
+++ b/bagofholding/h5/triebag.py
@@ -25,6 +25,18 @@ IntArrayType: TypeAlias = np.ndarray[tuple[int, ...], IntTypesAlias]
 
 
 class TrieH5Bag(Bag, HasH5FileContext, ArrayPacker):
+    """
+    A bag using HDF5 files based on `h5py`.
+
+    Uses a trie structure to flatten the stored object. Compared to
+    :class:`bagofholding.h5.bag.H5Bag`, this is advantageous for file sizes but
+    (currently)  has worse scaling for save times.
+
+    The resulting HDF5 file cannot be directly related to the structure of the stored
+    object, but must be re-mapped via mapping fields. Metadata is also lumped in with
+    other string data to minimize the number of different h5 groups.
+    """
+
     _content_key: ClassVar[str] = "content_type"
 
     _paths_key: ClassVar[str] = "paths"

--- a/bagofholding/metadata.py
+++ b/bagofholding/metadata.py
@@ -1,3 +1,7 @@
+"""
+Tools for extracting and logging information about python objects.
+"""
+
 from __future__ import annotations
 
 import dataclasses
@@ -12,6 +16,8 @@ from bagofholding.exceptions import EnvironmentMismatchError
 
 @dataclasses.dataclass(frozen=True)
 class HasFieldIterator:
+    """A simple helper mixin for dataclasses"""
+
     def field_items(self) -> ItemsView[str, str | None]:
         return dataclasses.asdict(self).items()
 
@@ -49,6 +55,21 @@ def get_version(
     module_name: str,
     version_scraping: VersionScrapingMap | None = None,
 ) -> str | None:
+    """
+    Given a module name, get its associated version (if any). By default, this simply
+    looks for the :attr:`__version__` attribute on the imported module.
+
+    For :mod:`builtins` this is just the python interpreter version.
+
+    Args:
+        module_name (str): The module to examine.
+        version_scraping (VersionScrapingMap | None): Since some modules may store
+            their version in other ways, this provides an optional map between module
+            names and callables to leverage for extracting that module's version.
+
+    Returns:
+        (str | None): The module's version as a string, if any can be found.
+    """
     if module_name == "builtins":
         return f"{version_info.major}.{version_info.minor}.{version_info.micro}"
 

--- a/bagofholding/retrieve.py
+++ b/bagofholding/retrieve.py
@@ -1,3 +1,7 @@
+"""
+Helper functions for managing the relationship between strings and imports.
+"""
+
 from __future__ import annotations
 
 from importlib import import_module

--- a/bagofholding/trie.py
+++ b/bagofholding/trie.py
@@ -121,6 +121,7 @@ class Helper:
     Useful tools for building tries on which to test the decomposition of path-like
     tree data.
     """
+
     @staticmethod
     def compute_softmax_weights(
         n: int, depth_propensity: float, temperature: float = 0.1


### PR DESCRIPTION
I'm very wary of overdoing documentation that isn't in the form of executable code, as it runs the high risk of simply becoming outdated. However, I think it's important to at least provide some more hints and suggestions at intent, and to make the structure of the package clearer with module docstrings indicating high-level relationships. This isn't complete/thorough documentation, but should go a long way towards those goals.

@jan-janssen, I actually had to rename this branch because my original intent had been to slide around the `TypeVar`s like we were talking about. I ran into something that should have been obvious: because most of them are explicitly bound to classes, they need to appear when the relevant class definition is already available -- e.g. `PackerType = TypeVar("PackerType", bound=Packer)` needs to appear after `class Packer(Protocol):`.
  Now, python is fully aware of this and there's an easy out by using strings for the bounds (`TypeVar("PackerType", bound="Packer")`, which makes everything delayed and thus OK. But I really like that the bounds are clickable and not going ever get missed in renamings etc. by virtue of being actual objects. So, I'm still not totally closed to the idea of more consolidated type declarations, but I continue to find reasons it's at least not a straightforward decision.
  Anyway, it probably would have been helpful to have these docstrings _before_ you went through the code, but at least the knowledge that someone else had bothered to look through it spurred me on to get this done 😝 