### PR TITLE
Slacken the benchmark test

### DIFF
--- a/tests/benchmark/test_benchmark.py
+++ b/tests/benchmark/test_benchmark.py
@@ -53,9 +53,11 @@ class TestBenchmark(unittest.TestCase):
                 print(f"H5 with-context benchmark: depth={depth}, reps={n_reps}")
                 self.assertLess(
                     dt_context,
-                    dt_direct,
+                    1.01 * dt_direct,
                     msg="Expected the with-context speed to be faster since the file "
-                    "is not re-opened multiple times",
+                        "is not re-opened multiple times...or at least much not slower -- "
+                        "locally it's always faster, but sometimes on the remote CI it is "
+                        "a hair slower and fails.",
                 )
                 print("With context", dt_context, "<", dt_direct, "Direct acces")
 

--- a/tests/benchmark/test_benchmark.py
+++ b/tests/benchmark/test_benchmark.py
@@ -55,9 +55,9 @@ class TestBenchmark(unittest.TestCase):
                     dt_context,
                     1.01 * dt_direct,
                     msg="Expected the with-context speed to be faster since the file "
-                        "is not re-opened multiple times...or at least much not slower -- "
-                        "locally it's always faster, but sometimes on the remote CI it is "
-                        "a hair slower and fails.",
+                    "is not re-opened multiple times...or at least much not slower -- "
+                    "locally it's always faster, but sometimes on the remote CI it is "
+                    "a hair slower and fails.",
                 )
                 print("With context", dt_context, "<", dt_direct, "Direct acces")
 


### PR DESCRIPTION
For the sake of the remote CI. The speed difference is so damned small, that sometimes noise on the machine makes the "faster" test slower. I don't care that strongly.

Closes #55

Or if it doesn't maybe we have a more real problem, but 1% slack should be tonnes.