### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.6
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.7
     secrets: inherit
     with:
       tests-env-files: .ci_support/environment.yml .ci_support/environment-widget.yml

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@actions-4.0.6
+    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@actions-4.0.7
     secrets: inherit

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-labeled.yml@actions-4.0.6
+    uses: pyiron/actions/.github/workflows/pr-labeled.yml@actions-4.0.7
     secrets: inherit

--- a/.github/workflows/pr-target-opened.yml
+++ b/.github/workflows/pr-target-opened.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@actions-4.0.6
+    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@actions-4.0.7
     secrets: inherit

--- a/.github/workflows/preview-hatch.yml
+++ b/.github/workflows/preview-hatch.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/hatch-release.yml@actions-4.0.6
+    uses: pyiron/actions/.github/workflows/hatch-release.yml@actions-4.0.7
     secrets: inherit
     with:
       semantic-upper-bound: 'minor'

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.6
+    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.7
     secrets: inherit
     with:
       notebooks-env-files: .ci_support/environment.yml .ci_support/environment-widget.yml

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -26,3 +26,4 @@ jobs:
       do-codacy: false
       do-coveralls: false
       do-mypy: true
+      coverage-test-dir: tests/unit tests/integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/hatch-release.yml@actions-4.0.6
+    uses: pyiron/actions/.github/workflows/hatch-release.yml@actions-4.0.7
     secrets: inherit
     with:
       semantic-upper-bound: 'minor'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.6
+    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.7
     secrets: inherit


### PR DESCRIPTION
To exclude the benchmark tests from the coverage job. It is slow -- I only want to run it _once_ in the explicit benchmark job. Let's try out the new pyiron/actions interface for providing multiple tests -- https://github.com/pyiron/actions/pull/154