### PR TITLE
Only benchmark pull requests

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -27,3 +27,4 @@ jobs:
       do-coveralls: false
       do-mypy: true
       coverage-test-dir: tests/unit tests/integration
+      do-benchmark-tests: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Not pushes to main. The benchmarks have a chance to fail stochastically, and anyhow they are there to see if changes we introduce are slowing things down, not to keep track of upstream dependencies.