### PR TITLE
Only run unit and integration

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -13,3 +13,4 @@ jobs:
     with:
       tests-env-files: .ci_support/environment.yml .ci_support/environment-widget.yml
       extra-python-paths: tests
+      test-dir: tests/unit tests/integration


### PR DESCRIPTION
The benchmarks are stochastic and don't want single-shot runs to cause failure.