### PR TITLE
Disable coverage check on dailies

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -14,3 +14,5 @@ jobs:
       tests-env-files: .ci_support/environment.yml .ci_support/environment-widget.yml
       extra-python-paths: tests
       test-dir: tests/unit tests/integration
+      do-codecov: false
+      do-coveralls: false


### PR DESCRIPTION
It only really makes sense to run the coverage when making a PR