### PR TITLE
Remove mpi4py dependence

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -5,7 +5,6 @@ dependencies:
 - h5py =3.14.0
 - hatchling =1.27.0
 - hatch-vcs =0.5.0
-- mpi4py =4.1.0
 - numpy =2.3.1
 - pygtrie =2.5.0
 - pyiron_snippets =0.2.0

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -5,7 +5,6 @@ dependencies:
 - h5py =3.14.0
 - hatchling =1.27.0
 - hatch-vcs =0.5.0
-- mpi4py =4.1.0
 - numpy =2.3.1
 - pygtrie =2.5.0
 - pyiron_snippets =0.2.0

--- a/.ci_support/lower_bound.yml
+++ b/.ci_support/lower_bound.yml
@@ -5,7 +5,6 @@ dependencies:
   - h5py =3.12.1
   - hatchling =1.27.0
   - hatch-vcs =0.5.0
-  - mpi4py =4.0.1
   - numpy =1.26.4
   - pygtrie =2.5.0
   - pyiron_snippets =0.1.4

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,7 +11,6 @@ dependencies:
 - h5py =3.14.0
 - hatchling =1.27.0
 - hatch-vcs =0.5.0
-- mpi4py =4.1.0
 - numpy =2.3.1
 - pygtrie =2.5.0
 - pyiron_snippets =0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
 dependencies = [
     "bidict==0.23.1",
     "h5py==3.14.0",
-    "mpi4py==4.1.0",
     "numpy==2.3.1",
     "pygtrie==2.5.0",
     "pyiron_snippets==0.2.0",


### PR DESCRIPTION
It was just for the [sake of h5py on python 3.13](https://github.com/pyiron/bagofholding/pull/43/commits/1768b0309e4509c6f5cc6e8fbdce82cdeb0be23e)