### PR TITLE
Drop mpi4py lower bound

### DIFF
--- a/.ci_support/lower_bound.yml
+++ b/.ci_support/lower_bound.yml
@@ -5,7 +5,7 @@ dependencies:
   - h5py =3.12.1
   - hatchling =1.27.0
   - hatch-vcs =0.5.0
-  - mpi4py =4.0.1
+  - mpi4py =3.0.0
   - numpy =1.26.4
   - pygtrie =2.5.0
   - pyiron_snippets =0.1.4


### PR DESCRIPTION
Just down to the last major version to see if that will help https://github.com/pyiron/docker-stacks/pull/586