### PR TITLE
Make importing from string more robust

### DIFF
--- a/bagofholding/retrieve.py
+++ b/bagofholding/retrieve.py
@@ -4,7 +4,7 @@ Helper functions for managing the relationship between strings and imports.
 
 from __future__ import annotations
 
-from importlib import import_module
+import importlib
 from typing import Any
 
 from bagofholding.exceptions import StringNotImportableError
@@ -16,9 +16,19 @@ def import_from_string(library_path: str) -> Any:
         module_name, path = split_path[0], ""
     else:
         module_name, path = split_path
-    obj = import_module(module_name)
+    obj = importlib.import_module(module_name)
     for k in path.split("."):
-        obj = getattr(obj, k)
+        try:
+            obj = getattr(obj, k)
+        except AttributeError:
+            # Try importing as a submodule
+            # This can be necessary of an __init__.py is empty and nothing else has
+            # referenced the module yet
+            current_path = f"{obj.__name__}.{k}"
+            try:
+                obj = importlib.import_module(current_path)
+            except ImportError:
+                raise AttributeError(f"module '{obj.__name__}' has no attribute '{k}'")
     return obj
 
 

--- a/bagofholding/retrieve.py
+++ b/bagofholding/retrieve.py
@@ -27,8 +27,10 @@ def import_from_string(library_path: str) -> Any:
             current_path = f"{obj.__name__}.{k}"
             try:
                 obj = importlib.import_module(current_path)
-            except ImportError:
-                raise AttributeError(f"module '{obj.__name__}' has no attribute '{k}'")
+            except ImportError as e:
+                raise AttributeError(
+                    f"module '{obj.__name__}' has no attribute '{k}'"
+                ) from e
     return obj
 
 


### PR DESCRIPTION
This is a nasty edge case when we try to get a submodule whose parent `__init__.py` is empty, and nothing else has referenced the module yet -- it doesn't appear in the parent `dir` to be item accessed. Under this condition, try a direct module import first.