### PR TITLE
Handle empty bytes specially

### DIFF
--- a/bagofholding/h5/bag.py
+++ b/bagofholding/h5/bag.py
@@ -146,7 +146,11 @@ class H5Bag(Bag, HasH5FileContext, ArrayPacker):
         return complex(data[0], data[1])
 
     def pack_bytes(self, obj: bytes, path: str) -> None:
-        self.file.create_dataset(path, data=np.void(obj))
+        if obj == b"":
+            special = h5py.special_dtype(vlen=bytes)
+            self.file.create_dataset(path, data=b"", dtype=special)
+        else:
+            self.file.create_dataset(path, data=np.void(obj))
 
     def unpack_bytes(self, path: str) -> bytes:
         return bytes(self._unpack_raw(path))

--- a/bagofholding/h5/triebag.py
+++ b/bagofholding/h5/triebag.py
@@ -54,6 +54,7 @@ class TrieH5Bag(Bag, HasH5FileContext, ArrayPacker):
             "array": 8,
             "empty": 9,
             "group": 10,
+            "empty_bytes": 11,
         }
     )
     _field_delimiter: ClassVar[str] = "::"
@@ -277,10 +278,17 @@ class TrieH5Bag(Bag, HasH5FileContext, ArrayPacker):
         return value
 
     def pack_bytes(self, obj: bytes, path: str) -> None:
-        self._pack_thing(obj, "bytes", path)
+        if obj == b"":
+            self._pack_trie(path, self._index_map["empty_bytes"], -1)
+        else:
+            self._pack_thing(obj, "bytes", path)
 
     def unpack_bytes(self, path: str) -> bytes:
-        return cast(bytes, self._read_pathlike(path).tobytes())
+        type_index, _ = self._read_trie(path)
+        if self._index_map.inverse[type_index] == "empty_bytes":
+            return b""
+        else:
+            return cast(bytes, self._read_pathlike(path).tobytes())
 
     def pack_bytearray(self, obj: bytearray, path: str) -> None:
         self._pack_thing(obj, "bytearray", path)

--- a/tests/unit/test_bag_implementations.py
+++ b/tests/unit/test_bag_implementations.py
@@ -109,6 +109,8 @@ class AbstractTestNamespace:
                 (bytes("some plain old bytes", encoding="utf8"), c.Bytes),
                 (b"\x00", c.Bytes),  # h5py leverages the null character, so we need to
                 # ensure we treat our bytes specially
+                (b"", c.Bytes),  # h5py can give size complaints about zero-length
+                # bytes, so test our the special handling there
                 (bytearray([42]), c.Bytearray),
             ]
             complex_items = [


### PR DESCRIPTION
`h5py` needs a bit of hand-holding to recover these zero-length objects.

Closes #100 