### PR TITLE
Allow paths into HDF5 files

### DIFF
--- a/bagofholding/h5/context.py
+++ b/bagofholding/h5/context.py
@@ -28,10 +28,24 @@ class HasH5FileContext:
     def file(self, new_file: h5py.File | None) -> None:
         self._file = new_file
 
-    def open(self, mode: Literal["r", "r+", "w", "w-", "x", "a"]) -> h5py.File:
+    def _parse_path(self) -> tuple[pathlib.Path, str]:
+        '''Break the given filepath into the actual file path and a group path inside the file.'''
+        path = self.filepath.absolute()
+        while not (path.suffix == ".h5" or path.is_file()) and path != pathlib.Path("/"):
+            path = path.parent
+        # found neither .h5 extension or existing path, just take the whole path as given
+        if path == pathlib.Path("/"):
+            return self.filepath, "/"
+        return path, str(self.filepath.absolute().relative_to(path))
+
+    def open(self, mode: Literal["r", "r+", "w", "w-", "x", "a"]) -> h5py.Group:
+        filepath, grouppath = self._parse_path()
         if self._file is None:
-            self.file = h5py.File(self.filepath, mode, libver=self.libver_str)
-            return self.file
+            self.file = h5py.File(filepath, mode, libver=self.libver_str)
+            try:
+                return self.file[grouppath]
+            except KeyError:
+                return self.file.create_group(grouppath)
         else:
             raise FileAlreadyOpenError(f"The bag at {self.filepath} is already open")
 

--- a/tests/unit/test_bag_implementations.py
+++ b/tests/unit/test_bag_implementations.py
@@ -251,37 +251,20 @@ class AbstractTestNamespace:
                 )
 
         def test_list_paths(self):
+            for sub in [
+                    "/subgroup",
+                    "/nested/subgroup",
+                    "/",
+            ]:
+                path = f"{self.save_name}.h5/{sub}"
+                obj = Parent()
+                self.bag_class().save(obj, path)
+                loaded_obj = self.bag_class()(path).load()
+                assert obj == loaded_obj
+
+        def test_sub_paths(self):
             self.bag_class().save(Parent(), self.save_name)
             paths = self.bag_class()(self.save_name).list_paths()
-            self.assertSetEqual(
-                {
-                    "object",
-                    "object/args",
-                    "object/args/i0",
-                    "object/constructor",
-                    "object/item_iterator",
-                    "object/kv_iterator",
-                    "object/state",
-                    "object/state/child",
-                    "object/state/child/args",
-                    "object/state/child/args/i0",
-                    "object/state/child/constructor",
-                    "object/state/child/item_iterator",
-                    "object/state/child/kv_iterator",
-                    "object/state/child/state",
-                    "object/state/child/state/data",
-                    "object/state/child/state/modified_data",
-                    "object/state/child/state/name",
-                    "object/state/child/state/parent",
-                    "object/state/data",
-                    "object/state/data/i0",
-                    "object/state/data/i1",
-                    "object/state/data/i2",
-                    "object/state/name",
-                },
-                set(paths),
-                msg=f"Got instead {paths}",
-            )
 
         def test_subaccess(self):
             r = Recursing(2)


### PR DESCRIPTION
Fixes #107 to allow placing multiple bags into the same HDF5 file. Paths to HDF5 bags are now interpreted as folder/file.h5/group/sub refering to the group in /group/sub inside the file folder/file.h5 In this implementation bagofholding will entirely ignore everything above the given group path.  This then allows to reuse the same file multiple times.